### PR TITLE
Add Polaris DBW package to publish brake command manually

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED
     roscpp
     std_srvs
     geometry_msgs
+    dbw_polaris_msgs
 )
 
 catkin_package(


### PR DESCRIPTION
This change was made during the qualifying stage of IGVC 2023.

This year the estop qualifying test required the vehicle to stop quicker than previous years.
Therefore, we were unable to use the 'coast' braking method. 

These changes were made to achieve the qualification in estop.